### PR TITLE
Add custom templates option

### DIFF
--- a/lib/bns/domain/birthday.rb
+++ b/lib/bns/domain/birthday.rb
@@ -8,6 +8,8 @@ module Domain
   class Birthday
     attr_reader :individual_name, :birth_date
 
+    ATTRIBUTES = %w[individual_name birth_date].freeze
+
     # Initializes a Domain::Birthday instance with the specified individual name, and date of birth.
     #
     # <br>

--- a/lib/bns/domain/pto.rb
+++ b/lib/bns/domain/pto.rb
@@ -9,6 +9,8 @@ module Domain
   class Pto
     attr_reader :individual_name, :start_date, :end_date
 
+    ATTRIBUTES = %w[individual_name start_date end_date].freeze
+
     # Initializes a Domain::Pto instance with the specified individual name, start date, and end date.
     #
     # <br>

--- a/lib/bns/formatter/base.rb
+++ b/lib/bns/formatter/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../domain/exceptions/function_not_implemented"
+require "erb"
 
 module Formatter
   ##
@@ -8,7 +9,7 @@ module Formatter
   # within the Formatter module. Defines essential methods, that provide a blueprint for creating custom
   # formatters tailored to different use cases.
   #
-  module Base
+  class Base
     # A method meant to give an specified format depending on the implementation to the data coming from an
     # implementation of the Mapper::Base interface.
     # Must be overridden by subclasses, with specific logic based on the use case.
@@ -22,8 +23,28 @@ module Formatter
     #
     # <b>returns</b> <tt>String</tt> Formatted payload suitable for a Dispatcher::Base implementation.
     #
+    attr_reader :template
+
+    def initialize(config = {})
+      @template = config[:template]
+    end
+
     def format(_domain_data)
       raise Domain::Exceptions::FunctionNotImplemented
+    end
+
+    protected
+
+    def build_template(attributes, instance)
+      formated_template = format_template(attributes, instance)
+
+      "#{ERB.new(formated_template).result(binding)}\n"
+    end
+
+    def format_template(attributes, _instance)
+      attributes.reduce(template) do |formated_template, attribute|
+        formated_template.gsub(attribute, "<%= instance.#{attribute} %>")
+      end
     end
   end
 end

--- a/lib/bns/formatter/discord/birthday.rb
+++ b/lib/bns/formatter/discord/birthday.rb
@@ -9,9 +9,7 @@ module Formatter
     ##
     # This class implementats the methods of the Formatter::Base module, specifically designed for formatting birthday
     # data in a way suitable for Discord messages.
-    class Birthday
-      include Base
-
+    class Birthday < Base
       # Implements the logic for building a formatted payload with the given template for birthdays.
       #
       # <br>
@@ -29,14 +27,9 @@ module Formatter
                                                                    brithday.is_a?(Domain::Birthday)
                                                                  end
 
-        template = "NAME, Wishing you a very happy birthday! Enjoy your special day! :birthday: :gift:"
-        payload = ""
-
-        birthdays_list.each do |birthday|
-          payload += "#{template.gsub("NAME", birthday.individual_name)}\n"
+        birthdays_list.reduce("") do |payload, birthday|
+          payload + build_template(Domain::Birthday::ATTRIBUTES, birthday)
         end
-
-        payload
       end
     end
   end

--- a/lib/bns/formatter/discord/pto.rb
+++ b/lib/bns/formatter/discord/pto.rb
@@ -8,9 +8,7 @@ module Formatter
     ##
     # This class is an implementation of the Formatter::Base interface, specifically designed for formatting PTO
     # data in a way suitable for Discord messages.
-    class Pto
-      include Base
-
+    class Pto < Base
       # Implements the logic for building a formatted payload with the given template for PTO's.
       #
       # <br>
@@ -23,17 +21,13 @@ module Formatter
       # <br>
       # <b>returns</b> <tt>String</tt> payload, formatted payload suitable for a Discord message.
       #
+
       def format(ptos_list)
         raise Formatter::Discord::Exceptions::InvalidData unless ptos_list.all? { |pto| pto.is_a?(Domain::Pto) }
 
-        template = ":beach: NAME is on PTO"
-        payload = ""
-
-        ptos_list.each do |pto|
-          payload += "#{template.gsub("NAME", pto.individual_name)} #{build_pto_message(pto)}\n"
+        ptos_list.reduce("") do |payload, pto|
+          payload + build_template(Domain::Pto::ATTRIBUTES, pto)
         end
-
-        payload
       end
 
       private

--- a/lib/bns/use_cases/use_cases.rb
+++ b/lib/bns/use_cases/use_cases.rb
@@ -73,7 +73,7 @@ module UseCases
   def self.notify_birthday_from_notion_to_discord(options)
     fetcher = Fetcher::Notion::Birthday.new(options[:fetch_options])
     mapper = Mapper::Notion::Birthday.new
-    formatter = Formatter::Discord::Birthday.new
+    formatter = Formatter::Discord::Birthday.new(options[:format_options])
     dispatcher = Dispatcher::Discord::Implementation.new(options[:dispatch_options])
     use_case_cofig = UseCases::Types::Config.new(fetcher, mapper, formatter, dispatcher)
 
@@ -141,7 +141,7 @@ module UseCases
   def self.notify_pto_from_notion_to_discord(options)
     fetcher = Fetcher::Notion::Pto.new(options[:fetch_options])
     mapper = Mapper::Notion::Pto.new
-    formatter = Formatter::Discord::Pto.new
+    formatter = Formatter::Discord::Pto.new(options[:format_options])
     dispatcher = Dispatcher::Discord::Implementation.new(options[:dispatch_options])
     use_case_cofig = UseCases::Types::Config.new(fetcher, mapper, formatter, dispatcher)
 

--- a/spec/bns/formatter/base_spec.rb
+++ b/spec/bns/formatter/base_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Formatter::Base do
-  describe ".format" do
-    let(:testing_class) { Class.new { include Formatter::Base } }
+  before do
+    config = {}
+    @formatter = described_class.new(config)
+  end
 
+  describe ".format" do
     it "provides no implementation for the method" do
-      instace = testing_class.new
       data = []
-      expect { instace.format(data) }.to raise_exception(Domain::Exceptions::FunctionNotImplemented)
+      expect { @formatter.format(data) }.to raise_exception(Domain::Exceptions::FunctionNotImplemented)
     end
   end
 end

--- a/spec/bns/formatter/discord/birthday_spec.rb
+++ b/spec/bns/formatter/discord/birthday_spec.rb
@@ -11,11 +11,16 @@ RSpec.describe Formatter::Discord::Birthday do
     it { expect(@formatter).to respond_to(:format).with(1).arguments }
   end
 
-  describe ".format" do
+  describe ".format with a custom template" do
+    before do
+      config = { template: "individual_name, Wishing you a very happy birthday! :birthday: :gift:" }
+      @formatter = described_class.new(config)
+    end
+
     it "format the given data into a specific message" do
       formatted_message = @formatter.format(@data)
-      expectation = "Jane Doe, Wishing you a very happy birthday! Enjoy your special day! :birthday: :gift:\n" \
-                    "John Doe, Wishing you a very happy birthday! Enjoy your special day! :birthday: :gift:\n"
+      expectation = "Jane Doe, Wishing you a very happy birthday! :birthday: :gift:\n" \
+                    "John Doe, Wishing you a very happy birthday! :birthday: :gift:\n"
 
       expect(formatted_message).to be_an_instance_of(String)
       expect(formatted_message).to eq(expectation)

--- a/spec/bns/formatter/discord/pto_spec.rb
+++ b/spec/bns/formatter/discord/pto_spec.rb
@@ -7,16 +7,21 @@ RSpec.describe Formatter::Discord::Pto do
       Domain::Pto.new("Time PTO", "2024-01-20T00:00:00.000-05:00", "2024-01-20T15:00:00.000-05:00"),
       Domain::Pto.new("Day PTO", "2024-01-11", "")
     ]
-
-    @formatter = described_class.new
   end
 
   describe "attributes and arguments" do
+    before { @formatter = described_class.new }
+
     it { expect(described_class).to respond_to(:new).with(0).arguments }
     it { expect(@formatter).to respond_to(:format).with(1).arguments }
   end
 
-  describe ".format" do
+  describe ".format with custom template" do
+    before do
+      config = { template: ":beach: individual_name is on PTO <%= build_pto_message(instance) %>" }
+      @formatter = described_class.new(config)
+    end
+
     it "format the given data into a specific message" do
       formatted_message = @formatter.format(@data)
       expectation = ":beach: Range PTO is on PTO all day\n" \


### PR DESCRIPTION
# Description
In this PR, a format_configuration was added to process custom templates based on the specific use case. The template should be included in the options map when initializing the use case (a required parameter). For example:

```ruby
 options = {
    format_options: {
      template: "Happy birthday individual_name, today birth_date is your day!"
    }
  }
```

In the template, the attributes of the respective use case domain can be set to be replaced by the corresponding data after execution.