### PR TITLE
Solve 28  - Add a Postgres fetcher component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,4 @@ gem "webmock"
 
 gem "httparty"
 
-gem 'pg', '~> 1.5', '>= 1.5.4'
+gem "pg", "~> 1.5", ">= 1.5.4"

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ gem "vcr"
 gem "webmock"
 
 gem "httparty"
+
+gem 'pg', '~> 1.5', '>= 1.5.4'

--- a/lib/bns/fetcher/postgres/helper.rb
+++ b/lib/bns/fetcher/postgres/helper.rb
@@ -7,7 +7,7 @@ module Fetcher
     #
     module Helper
       def self.validate_response(response)
-        response.response.check_result()
+        response.response.check_result
 
         response
       end

--- a/lib/bns/fetcher/postgres/helper.rb
+++ b/lib/bns/fetcher/postgres/helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Fetcher
+  module Postgres
+    ##
+    # Provides common fuctionalities along the Postgres domain.
+    #
+    module Helper
+      def self.validate_response(response)
+        response.response.check_result()
+
+        response
+      end
+    end
+  end
+end

--- a/lib/bns/fetcher/postgres/pto.rb
+++ b/lib/bns/fetcher/postgres/pto.rb
@@ -30,7 +30,7 @@ module Fetcher
       # Implements the data fetching logic for PTO's data from a Postgres database. It use the PG gem
       # to request data from a local or external database and returns a validated response.
       #
-      # Gem: pg (https://rubygems.org/gems/pg/versions/1.5.4)
+      # Gem: pg (https://rubygems.org/gems/pg)
       #
       def fetch
         pg_connection = PG::Connection.new(connection)

--- a/lib/bns/fetcher/postgres/pto.rb
+++ b/lib/bns/fetcher/postgres/pto.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'pg'
+
+require_relative "../base"
+require_relative "./types/response"
+require_relative "./helper"
+
+module Fetcher
+  module Postgres
+    class Pto < Base
+      attr_reader :connection, :query
+
+      def initialize(config)
+        @connection = config[:connection]
+        @query = config[:query]
+      end
+
+      def fetch
+        pg_connection = PG::Connection.new(connection)
+
+        pg_result = pg_connection.exec(query)
+
+        postgres_response = Fetcher::Postgres::Types::Response.new(pg_result)
+
+        Fetcher::Postgres::Helper.validate_response(postgres_response)
+      end
+    end
+  end
+end

--- a/lib/bns/fetcher/postgres/pto.rb
+++ b/lib/bns/fetcher/postgres/pto.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pg'
+require "pg"
 
 require_relative "../base"
 require_relative "./types/response"
@@ -8,10 +8,16 @@ require_relative "./helper"
 
 module Fetcher
   module Postgres
+    ##
+    # This class is an implementation of the Fetcher::Base interface, specifically designed
+    # for fetching Paid Time Off (PTO) data from a Postgres Database.
+    #
     class Pto < Base
       attr_reader :connection, :query
 
       def initialize(config)
+        super(config)
+
         @connection = config[:connection]
         @query = config[:query]
       end

--- a/lib/bns/fetcher/postgres/pto.rb
+++ b/lib/bns/fetcher/postgres/pto.rb
@@ -15,6 +15,11 @@ module Fetcher
     class Pto < Base
       attr_reader :connection, :query
 
+      # Initializes the Postgres fetcher with essential configuration parameters.
+      #
+      # <b>connection config</b> : valid format are the same as the ones defined on the pg gem (https://deveiate.org/code/pg/PG/Connection.html)
+      # <br>
+      # <b>query format</b> : valid format are the same as the ones defined on the pg gem (https://deveiate.org/code/pg/PG/Connection.html)
       def initialize(config)
         super(config)
 
@@ -22,6 +27,11 @@ module Fetcher
         @query = config[:query]
       end
 
+      # Implements the data fetching logic for PTO's data from a Postgres database. It use the PG gem
+      # to request data from a local or external database and returns a validated response.
+      #
+      # Gem: pg (https://rubygems.org/gems/pg/versions/1.5.4)
+      #
       def fetch
         pg_connection = PG::Connection.new(connection)
 

--- a/lib/bns/fetcher/postgres/types/response.rb
+++ b/lib/bns/fetcher/postgres/types/response.rb
@@ -9,24 +9,32 @@ module Fetcher
       class Response
         attr_reader :status, :message, :response, :fields, :records
 
-        SUCCESS_STATUS = 'PGRES_TUPLES_OK'
+        SUCCESS_STATUS = "PGRES_TUPLES_OK"
 
         def initialize(response)
-          status = response.res_status()
-
-          if status == SUCCESS_STATUS
-            @status = status
-            @message = 'success'
-            @response = response
-            @fields = response.fields()
-            @records = response.values
+          if response.res_status == SUCCESS_STATUS
+            success_response(response)
           else
-            @status = status
-            @message = response.result_error_message()
-            @response = response
-            @fields = nil
-            @records = nil
+            unsuccess_response(response)
           end
+        end
+
+        private
+
+        def success_response(response)
+          @status = response.res_status
+          @message = "success"
+          @response = response
+          @fields = response.fields
+          @records = response.values
+        end
+
+        def unsuccess_response(response)
+          @status = response.res_status
+          @message = response.result_error_message
+          @response = response
+          @fields = nil
+          @records = nil
         end
       end
     end

--- a/lib/bns/fetcher/postgres/types/response.rb
+++ b/lib/bns/fetcher/postgres/types/response.rb
@@ -15,7 +15,7 @@ module Fetcher
           if response.res_status == SUCCESS_STATUS
             success_response(response)
           else
-            unsuccess_response(response)
+            failure_response(response)
           end
         end
 
@@ -29,7 +29,7 @@ module Fetcher
           @records = response.values
         end
 
-        def unsuccess_response(response)
+        def failure_response(response)
           @status = response.res_status
           @message = response.result_error_message
           @response = response

--- a/lib/bns/fetcher/postgres/types/response.rb
+++ b/lib/bns/fetcher/postgres/types/response.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Fetcher
+  module Postgres
+    module Types
+      ##
+      # Represents a response received from the Postgres API. It encapsulates essential information about the response,
+      # providing a structured way to handle and analyze it's responses.
+      class Response
+        attr_reader :status, :message, :response, :fields, :records
+
+        SUCCESS_STATUS = 'PGRES_TUPLES_OK'
+
+        def initialize(response)
+          status = response.res_status()
+
+          if status == SUCCESS_STATUS
+            @status = status
+            @message = 'success'
+            @response = response
+            @fields = response.fields()
+            @records = response.values
+          else
+            @status = status
+            @message = response.result_error_message()
+            @response = response
+            @fields = nil
+            @records = nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bns/use_cases/use_cases.rb
+++ b/lib/bns/use_cases/use_cases.rb
@@ -4,6 +4,7 @@ require_relative "../fetcher/notion/birthday"
 require_relative "../mapper/notion/birthday"
 require_relative "../formatter/discord/birthday"
 
+require_relative "../fetcher/postgres/pto"
 require_relative "../fetcher/notion/pto"
 require_relative "../mapper/notion/pto"
 require_relative "../formatter/discord/pto"

--- a/spec/bns/fetcher/postgres/pto_spec.rb
+++ b/spec/bns/fetcher/postgres/pto_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Fetcher::Postgres::Pto do
       expect(pg_response.records).to eq(values)
     end
 
-    it "fetch data from the postgres database when there are not results" do
+    it "fetch data from the postgres database when there are no results" do
       allow(@pg_result).to receive(:fields).and_return([])
       allow(@pg_result).to receive(:values).and_return([])
       allow(@pg_result).to receive(:res_status).and_return("PGRES_TUPLES_OK")
@@ -67,7 +67,7 @@ RSpec.describe Fetcher::Postgres::Pto do
       expect(pg_response.records).to eq([])
     end
 
-    it "fetch data from the postgres databases with an unsucess status" do
+    it "fetch data from the postgres databases with a failure status" do
       allow(@pg_result).to receive(:res_status).and_return("PGRES_EMPTY_QUERY")
       allow(@pg_result).to receive(:result_error_message).and_return("the query is empty")
       allow(@pg_result).to receive(:check_result).and_return(nil)

--- a/spec/bns/fetcher/postgres/pto_spec.rb
+++ b/spec/bns/fetcher/postgres/pto_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Fetcher::Postgres::Pto do
   before do
-    today = '2024-02-14 16:40:08 UTC'
+    today = "2024-02-14 16:40:08 UTC"
     query = "SELECT * FROM pto WHERE start_date <= '#{today}' AND end_date >= '#{today}';"
 
     config = {
@@ -28,11 +28,11 @@ RSpec.describe Fetcher::Postgres::Pto do
 
   describe ".fetch" do
     let(:pg_conn) { instance_double(PG::Connection) }
-    let(:fields) { ['id', 'individual_name', 'start_date', 'end_date'] }
-    let(:values) { [["5", "2024-02-13", "user1", "2024-02-13", "2024-02-14"]] }
+    let(:fields) { %w[id individual_name start_date end_date] }
+    let(:values) { [%w[5 2024-02-13 user1 2024-02-13 2024-02-14]] }
 
     before do
-      @pg_result = double()
+      @pg_result = double
 
       allow(@pg_result).to receive(:fields).and_return(fields)
       allow(@pg_result).to receive(:values).and_return(values)
@@ -42,13 +42,13 @@ RSpec.describe Fetcher::Postgres::Pto do
     end
 
     it "fetch data from the postgres database when there are results" do
-      allow(@pg_result).to receive(:res_status).and_return('PGRES_TUPLES_OK')
+      allow(@pg_result).to receive(:res_status).and_return("PGRES_TUPLES_OK")
       allow(@pg_result).to receive(:check_result).and_return(nil)
 
       pg_response = @fetcher.fetch
 
-      expect(pg_response.status).to eq('PGRES_TUPLES_OK')
-      expect(pg_response.message).to eq('success')
+      expect(pg_response.status).to eq("PGRES_TUPLES_OK")
+      expect(pg_response.message).to eq("success")
       expect(pg_response.fields).to eq(fields)
       expect(pg_response.records).to eq(values)
     end
@@ -56,38 +56,38 @@ RSpec.describe Fetcher::Postgres::Pto do
     it "fetch data from the postgres database when there are not results" do
       allow(@pg_result).to receive(:fields).and_return([])
       allow(@pg_result).to receive(:values).and_return([])
-      allow(@pg_result).to receive(:res_status).and_return('PGRES_TUPLES_OK')
+      allow(@pg_result).to receive(:res_status).and_return("PGRES_TUPLES_OK")
       allow(@pg_result).to receive(:check_result).and_return(nil)
 
       pg_response = @fetcher.fetch
 
-      expect(pg_response.status).to eq('PGRES_TUPLES_OK')
-      expect(pg_response.message).to eq('success')
+      expect(pg_response.status).to eq("PGRES_TUPLES_OK")
+      expect(pg_response.message).to eq("success")
       expect(pg_response.fields).to eq([])
       expect(pg_response.records).to eq([])
     end
 
     it "fetch data from the postgres databases with an unsucess status" do
-      allow(@pg_result).to receive(:res_status).and_return('PGRES_EMPTY_QUERY')
-      allow(@pg_result).to receive(:result_error_message).and_return('the query is empty')
+      allow(@pg_result).to receive(:res_status).and_return("PGRES_EMPTY_QUERY")
+      allow(@pg_result).to receive(:result_error_message).and_return("the query is empty")
       allow(@pg_result).to receive(:check_result).and_return(nil)
 
       pg_response = @fetcher.fetch
 
-      expect(pg_response.status).to eq('PGRES_EMPTY_QUERY')
-      expect(pg_response.message).to eq('the query is empty')
+      expect(pg_response.status).to eq("PGRES_EMPTY_QUERY")
+      expect(pg_response.message).to eq("the query is empty")
       expect(pg_response.fields).to eq(nil)
       expect(pg_response.records).to eq(nil)
     end
 
     it "fetch data from the postgres databases with a bad state" do
-      error_to_raise = PG::Error.new()
+      error_to_raise = PG::Error.new
 
-      allow(@pg_result).to receive(:res_status).and_return('PGRES_BAD_RESPONSE')
-      allow(@pg_result).to receive(:result_error_message).and_return('bad response')
+      allow(@pg_result).to receive(:res_status).and_return("PGRES_BAD_RESPONSE")
+      allow(@pg_result).to receive(:result_error_message).and_return("bad response")
       allow(@pg_result).to receive(:check_result).and_raise(error_to_raise)
 
-      expect {@fetcher.fetch}.to raise_exception(error_to_raise)
+      expect { @fetcher.fetch }.to raise_exception(error_to_raise)
     end
   end
 end

--- a/spec/bns/fetcher/postgres/pto_spec.rb
+++ b/spec/bns/fetcher/postgres/pto_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Fetcher::Postgres::Pto do
+  before do
+    today = '2024-02-14 16:40:08 UTC'
+    query = "SELECT * FROM pto WHERE start_date <= '#{today}' AND end_date >= '#{today}';"
+
+    config = {
+      connection: {
+        host: "localhost",
+        port: 5432,
+        dbname: "db_pto",
+        user: "postgres",
+        password: "postgres"
+      },
+      query: query
+    }
+
+    @fetcher = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@fetcher).to respond_to(:config) }
+    it { expect(@fetcher).to respond_to(:fetch).with(0).arguments }
+  end
+
+  describe ".fetch" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:fields) { ['id', 'individual_name', 'start_date', 'end_date'] }
+    let(:values) { [["5", "2024-02-13", "user1", "2024-02-13", "2024-02-14"]] }
+
+    before do
+      @pg_result = double()
+
+      allow(@pg_result).to receive(:fields).and_return(fields)
+      allow(@pg_result).to receive(:values).and_return(values)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec).and_return(@pg_result)
+    end
+
+    it "fetch data from the postgres database when there are results" do
+      allow(@pg_result).to receive(:res_status).and_return('PGRES_TUPLES_OK')
+      allow(@pg_result).to receive(:check_result).and_return(nil)
+
+      pg_response = @fetcher.fetch
+
+      expect(pg_response.status).to eq('PGRES_TUPLES_OK')
+      expect(pg_response.message).to eq('success')
+      expect(pg_response.fields).to eq(fields)
+      expect(pg_response.records).to eq(values)
+    end
+
+    it "fetch data from the postgres database when there are not results" do
+      allow(@pg_result).to receive(:fields).and_return([])
+      allow(@pg_result).to receive(:values).and_return([])
+      allow(@pg_result).to receive(:res_status).and_return('PGRES_TUPLES_OK')
+      allow(@pg_result).to receive(:check_result).and_return(nil)
+
+      pg_response = @fetcher.fetch
+
+      expect(pg_response.status).to eq('PGRES_TUPLES_OK')
+      expect(pg_response.message).to eq('success')
+      expect(pg_response.fields).to eq([])
+      expect(pg_response.records).to eq([])
+    end
+
+    it "fetch data from the postgres databases with an unsucess status" do
+      allow(@pg_result).to receive(:res_status).and_return('PGRES_EMPTY_QUERY')
+      allow(@pg_result).to receive(:result_error_message).and_return('the query is empty')
+      allow(@pg_result).to receive(:check_result).and_return(nil)
+
+      pg_response = @fetcher.fetch
+
+      expect(pg_response.status).to eq('PGRES_EMPTY_QUERY')
+      expect(pg_response.message).to eq('the query is empty')
+      expect(pg_response.fields).to eq(nil)
+      expect(pg_response.records).to eq(nil)
+    end
+
+    it "fetch data from the postgres databases with a bad state" do
+      error_to_raise = PG::Error.new()
+
+      allow(@pg_result).to receive(:res_status).and_return('PGRES_BAD_RESPONSE')
+      allow(@pg_result).to receive(:result_error_message).and_return('bad response')
+      allow(@pg_result).to receive(:check_result).and_raise(error_to_raise)
+
+      expect {@fetcher.fetch}.to raise_exception(error_to_raise)
+    end
+  end
+end


### PR DESCRIPTION
Closes #28 

# Description
In this PR a Postgres fetcher was added for the PTO use case. The [pg gem](https://rubygems.org/gems/pg/versions/1.5.4) was used for the implementation, and some tests were added. The fetcher expects an input like: 

```ruby
options = {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "db_pto",
      user: "postgres",
      password: "postgres"
    },
    query: "SELECT * FROM db_pto"
  }
```