### PR TITLE
Solve #48 - Dynamic WIP limit value

### DIFF
--- a/lib/bns/domain/work_items_limit.rb
+++ b/lib/bns/domain/work_items_limit.rb
@@ -3,37 +3,23 @@
 module Domain
   ##
   # The Domain::WorkItemsLimit class provides a domain-specific representation of a Work Item object.
-  # It encapsulates information about a work items limit, including the domain, total, and wip_limit.
+  # It encapsulates information about a work items limit, including the domain and total.
   #
   class WorkItemsLimit
-    attr_reader :domain, :total, :wip_limit
+    attr_reader :domain, :total
 
-    ATTRIBUTES = %w[domain total wip_limit].freeze
+    ATTRIBUTES = %w[domain total].freeze
 
-    # Initializes a Domain::WorkItemsLimit instance with the specified domain, total and wip_limit.
+    # Initializes a Domain::WorkItemsLimit instance with the specified domain and total.
     #
     # <br>
     # <b>Params:</b>
     # * <tt>String</tt> 'domain' responsible domain of the work items.
     # * <tt>String</tt> 'total' total 'in progress' work items.
-    # * <tt>String</tt> 'wip_limit' maximum 'in progress' work items for the domain
     #
     def initialize(domain, total)
       @domain = domain
       @total = total
-      @wip_limit = domain_wip_limit(domain)
-    end
-
-    private
-
-    def domain_wip_limit(domain)
-      case domain
-      when "kommit.ops" then 6
-      when "kommit.sales" then 3
-      when "kommit.marketing" then 4
-      when "kommit.engineering" then 12
-      else 6
-      end
     end
   end
 end

--- a/lib/bns/formatter/work_items_limit.rb
+++ b/lib/bns/formatter/work_items_limit.rb
@@ -9,7 +9,16 @@ module Formatter
   # This class implements methods from the Formatter::Base module, tailored to format the
   # Domain::WorkItemsLimit structure for a dispatcher.
   class WorkItemsLimit < Base
-    attr_reader :limit
+    DEFAULT_DOMAIN_LIMIT = 6
+
+    # Initializes the formatter with essential configuration parameters.
+    #
+    # <b>limits</b> : expect a map with the wip limits by domain. Example: { "ops": 5 }
+    def initialize(config = {})
+      super(config)
+
+      @limits = config[:limits]
+    end
 
     # Implements the logic for building a formatted payload with the given template for wip limits.
     #
@@ -30,14 +39,26 @@ module Formatter
       end
 
       exceeded_domains(work_items_list).reduce("") do |payload, work_items_limit|
-        payload + build_template(Domain::WorkItemsLimit::ATTRIBUTES, work_items_limit)
+        built_template = build_template(Domain::WorkItemsLimit::ATTRIBUTES, work_items_limit)
+        payload + format_message_by_case(built_template.gsub("\n", ""), work_items_limit)
       end
     end
 
     private
 
+    def format_message_by_case(template, work_items_limit)
+      total_items = work_items_limit.total
+      limit = domain_limit(work_items_limit.domain)
+
+      template + ", #{total_items} of #{limit}\n"
+    end
+
     def exceeded_domains(work_items_list)
-      work_items_list.filter { |work_item| work_item.total > work_item.wip_limit }
+      work_items_list.filter { |work_item| work_item.total > domain_limit(work_item.domain) }
+    end
+
+    def domain_limit(domain)
+      @limits[domain.to_sym] || DEFAULT_DOMAIN_LIMIT
     end
   end
 end

--- a/spec/bns/formatter/work_items_limit_spec.rb
+++ b/spec/bns/formatter/work_items_limit_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Formatter::WorkItemsLimit do
   describe ".format with custom template" do
     before do
       options = {
-        template: "The domain work-board wip limit was exceeded, total of wip_limit"
+        template: "The domain work-board wip limit was exceeded",
+        limits: { "kommit.marketing": 4 }
       }
 
       @formatter = described_class.new(options)


### PR DESCRIPTION
Closes #48 

## Description
In this PR the hard-coded wip limits were removed and a new format configuration was added to the wip limits use case. The new configuration is call limits, and it should be a map where the domain limits are defined. For example: 
```ruby
{
  "ops": 3,
  "marketing": 5,
  "engineering": 8
}
```